### PR TITLE
Remove redundant null checks in AuthenticationManager

### DIFF
--- a/src/FlowCtl.Infrastructure/Services/Authentication/AuthenticationManager.cs
+++ b/src/FlowCtl.Infrastructure/Services/Authentication/AuthenticationManager.cs
@@ -60,10 +60,11 @@ public class AuthenticationManager : IAuthenticationManager
             if (data.Username != null)
                 data.Username = _protector.Unprotect(data.Username);
 
-            if (data?.Type == AuthenticationType.Basic && data.Password != null)
+            // data is guaranteed non-null within this scope, so we can evaluate authentication type directly.
+            if (data.Type == AuthenticationType.Basic && data.Password != null)
                 data.Password = _protector.Unprotect(data.Password);
-            
-            if (data?.Type == AuthenticationType.Bearer && data.AccessToken != null)
+
+            if (data.Type == AuthenticationType.Bearer && data.AccessToken != null)
                 data.AccessToken = _protector.Unprotect(data.AccessToken);
         }
 


### PR DESCRIPTION
## Summary
- remove redundant null-conditional operators around `data.Type` inside `AuthenticationManager.GetData`
- document the non-null invariant to help future refactors and align with the repo's emphasis on explicit authentication flows

## Design Decisions & Rationale
- rely on the surrounding `if (data != null)` guard instead of chaining null-conditionals, which keeps the checks simpler and avoids redundant short-circuiting
- retain the per-property decryption sequence used elsewhere in `AuthenticationManager` while adding a brief comment about the invariant for clarity

## Tests
- `dotnet test FlowCtl.sln`
- `dotnet format --verify-no-changes FlowCtl.sln --include src/FlowCtl.Infrastructure/Services/Authentication/AuthenticationManager.cs`

## Alignment with Repository Patterns & Objectives
- mirrors the existing pattern of decrypting each credential field only when populated
- reinforces the authentication module's goal of deterministic, reliable credential handling by documenting assumptions alongside the code
- keeps the infrastructure layer lightweight by avoiding unnecessary checks, which aligns with the project's emphasis on efficient CLI operations

Closes #119.
