### PR TITLE
Make JsonSerializer ContentMineType static

### DIFF
--- a/src/FlowCtl.Infrastructure/Serialization/JsonSerializer.cs
+++ b/src/FlowCtl.Infrastructure/Serialization/JsonSerializer.cs
@@ -7,7 +7,10 @@ namespace FlowCtl.Infrastructure.Serialization;
 
 public class JsonSerializer : IJsonSerializer
 {
-    public string ContentMineType => "application/json";
+    /// <summary>
+    /// Static JSON content type reference that callers can reuse without instantiating the serializer.
+    /// </summary>
+    public static string ContentMineType => "application/json";
 
     public string Serialize(object? input)
     {

--- a/tests/FlowCtl.Infrastructure.UnitTests/Serialization/JsonSerializerTests.cs
+++ b/tests/FlowCtl.Infrastructure.UnitTests/Serialization/JsonSerializerTests.cs
@@ -7,6 +7,16 @@ namespace FlowCtl.Infrastructure.UnitTests.Serialization;
 public class JsonSerializerTests
 {
     [Fact]
+    public void ContentMineType_ShouldExposeJsonMimeTypeWithoutInstance()
+    {
+        // Act
+        var mimeType = JsonSerializer.ContentMineType;
+
+        // Assert
+        Assert.Equal("application/json", mimeType);
+    }
+
+    [Fact]
     public void Serialize_ShouldThrowFlowSynxException_WhenInputIsNull()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- expose `JsonSerializer.ContentMineType` as a static property so callers can reuse the MIME type without instantiating the serializer
- document the invariant with a short XML summary to match the repo's comment-heavy style
- add a focused unit test proving the property works as a static member

## Design Decisions & Rationale
- keeping the constant as a static property maintains the existing API surface while communicating that the value is instance-agnostic
- XML documentation mirrors other infrastructure services and clarifies why the property exists
- a lightweight test guards against future regressions if the MIME type changes or is made configurable

## Tests
- `dotnet test FlowCtl.sln`
- `dotnet format --verify-no-changes FlowCtl.sln --include src/FlowCtl.Infrastructure/Serialization/JsonSerializer.cs tests/FlowCtl.Infrastructure.UnitTests/Serialization/JsonSerializerTests.cs`

## Alignment with Repository Patterns & Objectives
- reinforces the repository's goal of reliable serialization infrastructure by centralizing the CLI's default content type
- follows the unit-test-first culture by extending the existing `JsonSerializerTests`
- keeps the CLI efficient by avoiding unnecessary allocations for constant data

Closes #118.
