### PR TITLE
Allow plugin install to default to latest (#125)

### DIFF
--- a/src/FlowCtl/Commands/Plugins/Install/InstallPluginCommand.cs
+++ b/src/FlowCtl/Commands/Plugins/Install/InstallPluginCommand.cs
@@ -9,8 +9,8 @@ internal class InstallPluginCommand : BaseCommand<InstallPluginCommandOptions, I
         var typeOption = new Option<string>(new[] { "-t", "--type" },
             description: Resources.Commands_Plugins_Install_TypeOption) { IsRequired = true };
 
-        var versionOption = new Option<string>(new[] { "-v", "--version" },
-            description: Resources.Commands_Plugins_VersionOption) { IsRequired = true };
+        var versionOption = new Option<string?>(new[] { "-v", "--version" },
+            description: Resources.Commands_Plugins_VersionOption);
 
         var addressOption = new Option<string?>(new[] { "-a", "--address" },
             description: Resources.Commands_FlowSynxAddress);

--- a/src/FlowCtl/Commands/Plugins/Install/InstallPluginCommandOptions.cs
+++ b/src/FlowCtl/Commands/Plugins/Install/InstallPluginCommandOptions.cs
@@ -2,7 +2,15 @@
 
 internal class InstallPluginCommandOptions : ICommandOptions
 {
+    /// <summary>
+    /// FlowSynx plugin identifier (e.g. email-sender).
+    /// </summary>
     public required string Type { get; set; }
-    public required string Version { get; set; }
+
+    /// <summary>
+    /// Optional plugin version; defaults to the FlowSynx "latest" tag.
+    /// </summary>
+    public string? Version { get; set; }
+
     public string? Address { get; set; } = string.Empty;
 }

--- a/src/FlowCtl/Properties/AssemblyInfo.cs
+++ b/src/FlowCtl/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("FlowCtl.UnitTests")]

--- a/src/FlowCtl/Resources.Designer.cs
+++ b/src/FlowCtl/Resources.Designer.cs
@@ -644,6 +644,15 @@ namespace FlowCtl {
                 return ResourceManager.GetString("Commands_Plugins_InstallDescription", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to No plugin version was specified; using &apos;{0}&apos;..
+        /// </summary>
+        internal static string Commands_Plugins_Install_DefaultVersionInfo {
+            get {
+                return ResourceManager.GetString("Commands_Plugins_Install_DefaultVersionInfo", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Specifies the new plugin version should be installed..

--- a/src/FlowCtl/Resources.resx
+++ b/src/FlowCtl/Resources.resx
@@ -282,6 +282,9 @@
   <data name="Commands_Plugins_InstallDescription" xml:space="preserve">
     <value>Install plugin</value>
   </data>
+  <data name="Commands_Plugins_Install_DefaultVersionInfo" xml:space="preserve">
+    <value>No plugin version was specified; using '{0}'.</value>
+  </data>
   <data name="Commands_Plugins_Install_TypeOption" xml:space="preserve">
     <value>Specifies the plugin type should be installed.</value>
   </data>
@@ -301,7 +304,7 @@
     <value>Update plugin</value>
   </data>
   <data name="Commands_Plugins_VersionOption" xml:space="preserve">
-    <value>Specifies the plugin version should be installed.</value>
+    <value>Specifies the plugin version to install. Defaults to 'latest' when omitted.</value>
   </data>
   <data name="Commands_RootDescription" xml:space="preserve">
     <value>flowctl controls the FlowSynx engine</value>

--- a/tests/FlowCtl.UnitTests/Commands/Plugins/InstallPluginCommandOptionsHandlerTests.cs
+++ b/tests/FlowCtl.UnitTests/Commands/Plugins/InstallPluginCommandOptionsHandlerTests.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FlowCtl.Commands.Plugins.Install;
+using FlowCtl.Core.Services.Authentication;
+using FlowCtl.Core.Services.Logger;
+using FlowSynx.Client;
+using FlowSynx.Client.Authentication;
+using FlowSynx.Client.Messages.Requests.Plugins;
+using FlowSynx.Client.Messages.Responses;
+using FlowSynx.Client.Services;
+using Moq;
+
+namespace FlowCtl.UnitTests.Commands.Plugins;
+
+public class InstallPluginCommandOptionsHandlerTests
+{
+    [Fact]
+    public async Task HandleAsync_DefaultsToLatestVersion_WhenVersionIsMissing()
+    {
+        // Arrange
+        var loggerMock = new Mock<IFlowCtlLogger>();
+        var pluginsServiceMock = new Mock<IPluginsService>();
+        var flowSynxClientMock = new Mock<IFlowSynxClient>();
+        var authenticationManagerMock = CreateAuthenticationManagerMock();
+
+        flowSynxClientMock.Setup(client => client.Plugins)
+            .Returns(pluginsServiceMock.Object);
+        flowSynxClientMock.Setup(client => client.SetAuthenticationStrategy(It.IsAny<IAuthenticationStrategy>()));
+
+        pluginsServiceMock.Setup(service => service.InstallAsync(
+                It.Is<InstallPluginRequest>(request => request.Version == "latest"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateSuccessfulInstallResult());
+
+        var handler = new InstallPluginCommandOptionsHandler(
+            loggerMock.Object,
+            flowSynxClientMock.Object,
+            authenticationManagerMock.Object);
+
+        var options = new InstallPluginCommandOptions
+        {
+            Type = "email-sender",
+            Version = null
+        };
+
+        // Act
+        await handler.HandleAsync(options, CancellationToken.None);
+
+        // Assert
+        pluginsServiceMock.Verify(service => service.InstallAsync(
+            It.Is<InstallPluginRequest>(request => request.Version == "latest"),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        loggerMock.Verify(logger => logger.Write(
+                It.Is<string>(message => message.Contains("latest", StringComparison.OrdinalIgnoreCase))),
+            Times.Once);
+    }
+
+    private static Mock<IAuthenticationManager> CreateAuthenticationManagerMock()
+    {
+        var mock = new Mock<IAuthenticationManager>();
+        mock.SetupGet(manager => manager.IsLoggedIn).Returns(true);
+        mock.SetupGet(manager => manager.IsBasicAuthenticationUsed).Returns(false);
+        mock.Setup(manager => manager.GetData())
+            .Returns(new AuthenticationData { AccessToken = "token" });
+        return mock;
+    }
+
+    private static HttpResult<Result<Unit>> CreateSuccessfulInstallResult() =>
+        new()
+        {
+            StatusCode = 200,
+            Payload = new Result<Unit>
+            {
+                Succeeded = true,
+                Data = new Unit(),
+                Messages = new List<string>()
+            }
+        };
+}


### PR DESCRIPTION
## Summary
- make the plugin install version option optional and default to FlowSynx's "latest" tag, aligning with the CLI option/help conventions
- emit a localized log when the fallback is used and keep request creation centralized so it always uses the resolved version
- expose FlowCtl internals to the unit test project and cover the defaulting behavior with a new handler test

## Testing
- dotnet test FlowCtl.sln

Closes #125.